### PR TITLE
Prevent SEO from indexing logto.qubitpi.org

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -165,6 +165,7 @@ const config: Config = {
   title: 'Logto docs',
   url: 'https://logto.qubitpi.org',
   baseUrl: '/',
+  noIndex: true,
   onBrokenLinks: 'throw',
   onBrokenAnchors: 'throw',
   onBrokenMarkdownLinks: 'throw',


### PR DESCRIPTION
Since this fork is meant for personal study and part of my team's customized knowledge hub, it will step away from public view by turning off SEO indexing on it so that it doesn't steal the traffic away from official logto docs

Reference - https://docusaurus.qubitpi.org/docs/api/docusaurus-config#noIndex